### PR TITLE
local branch should match remote branch

### DIFF
--- a/lib/Toadfarm/Plugin/Reload.pm
+++ b/lib/Toadfarm/Plugin/Reload.pm
@@ -209,7 +209,7 @@ sub _refresh_repo {
     "$config->{remote}/$config->{branch}",
     sub {
       return $self->{log}->error("Invalid commit: $_[0] ne $sha1") unless $_[0] eq $sha1;
-      $self->_run($GIT => checkout => -f => -B => toadfarm_reload_branch => "$config->{remote}/$config->{branch}");
+      $self->_run($GIT => checkout => -f => -B => $config->{branch} => "$config->{remote}/$config->{branch}");
     }
   );
 }


### PR DESCRIPTION
Either documentation should explain that (and why) the remote specified branch merges to local branch toadfarm_reload_branch or the remote branch should merge to the local repo by the same branch name (this pull request).