### PR TITLE
improve documentation

### DIFF
--- a/lib/Toadfarm/Plugin/Reload.pm
+++ b/lib/Toadfarm/Plugin/Reload.pm
@@ -23,7 +23,8 @@ Go to "https://github.com/YOUR-USERNAME/YOUR-REPO/settings/hooks" to set it up.
 =item *
 
 The WebHook URL needs to be "http://yourserver.com/some/secret/path" and
-should not trigger any of the mounted apps.
+should not trigger any of the mounted apps, e.g. with Virtual Hosting, the
+webhook URL host should be unique from the mounted apps.
 
 =back
 


### PR DESCRIPTION
This probably isn't the best message, but I think it could be really helpful to be specifically clear about this example.  I don't think it's immediately clear that the webhook URL that you specify in GitHub should not be of the same host name as one of the mounted apps.  When it is incorrectly configured this way, GitHub merely gets an unhelpful 404 response.  Of course the reason why is that the mounted app picks up on the host name specified in the Github webhook and of course that route is not configured; but this isn't necessarily obvious, nor is the solution: pick an altogether separate hostname such as prepending _ to the hostname as in http://_my_app.example.com/reload/1/2/3/4/5 or perhaps some other preferred recommendation.