### PR TITLE
improve documentation

### DIFF
--- a/lib/Toadfarm/Manual/Config.pod
+++ b/lib/Toadfarm/Manual/Config.pod
@@ -32,7 +32,7 @@ for the request to get passed on to a given application.
   mount "Some::Application" => {
 
     # headers
-    "Host"           => "example.com",
+    "Host"           => qr{^(www.)?example.com$},
     "User-Agent"     => qr{curl},
     "X-Request-Base" => "http://example.com/whatever",
 


### PR DESCRIPTION
Just an idea to show that it's possible to match multiple Host headers in this way.  I know that should be obvious and especially clear from the next User-Agent example, but it seems like the need to match on example.com and www.example.com is pretty normal.