### PR TITLE
improve documentation

### DIFF
--- a/lib/Toadfarm/Plugin/Reload.pm
+++ b/lib/Toadfarm/Plugin/Reload.pm
@@ -23,11 +23,16 @@ Go to "https://github.com/YOUR-USERNAME/YOUR-REPO/settings/hooks" to set it up.
 =item *
 
 The WebHook URL needs to be "http://yourserver.com/some/private/path" and
-should not trigger any of the mounted apps. One way to do this is to specify
+should not trigger any of the mounted apps, e.g. with
+L<virtual hosts|Toadfarm::Manual::VirtualHost>, the hostname part of the
+WebHook URL needs to be unique from the mounted apps. This can be achieved by
+simply using an IP address instead of a hostname or exempting the GitHub-Hookshot
+User-Agent from the mount configuration.
 
-  "User-Agent" => qr{^(?:(?!GitHub-Hookshot).)*$}
-
-in the mount configuration.
+  mount 'My::App' => {
+    "Host" => qr{^(www.)?example.com$},
+    "User-Agent" => qr{^(?:(?!GitHub-Hookshot).)*$},
+  };
 
 =back
 

--- a/lib/Toadfarm/Plugin/Reload.pm
+++ b/lib/Toadfarm/Plugin/Reload.pm
@@ -22,15 +22,13 @@ Go to "https://github.com/YOUR-USERNAME/YOUR-REPO/settings/hooks" to set it up.
 
 =item *
 
-The WebHook URL needs to be "http://yourserver.com/some/private/path" and
-should not trigger any of the mounted apps, e.g. with
-L<virtual hosts|Toadfarm::Manual::VirtualHost>, the hostname part of the
-WebHook URL needs to be unique from the mounted apps. This can be achieved by
-simply using an IP address instead of a hostname or exempting the GitHub-Hookshot
-User-Agent from the mount configuration.
+The WebHook URL (e.g. http://yourserver.com/some/private/path), should not
+trigger any mounted apps. This can be achieved by simply using an IP address
+instead of a hostname or by exempting the GitHub-Hookshot User-Agent from the
+mount configuration:
 
   mount 'My::App' => {
-    "Host" => qr{^(www.)?example.com$},
+    "Host" => qr{^(www.)?yourserver.com$},
     "User-Agent" => qr{^(?:(?!GitHub-Hookshot).)*$},
   };
 

--- a/lib/Toadfarm/Plugin/Reload.pm
+++ b/lib/Toadfarm/Plugin/Reload.pm
@@ -22,11 +22,12 @@ Go to "https://github.com/YOUR-USERNAME/YOUR-REPO/settings/hooks" to set it up.
 
 =item *
 
-The WebHook URL needs to be "http://yourserver.com/some/secret/path" and
-should not trigger any of the mounted apps, e.g. with
-L<virtual hosts|Toadfarm::Manual::VirtualHost>, the hostname part of the
-WebHook URL need to be unique from the mounted apps. One way to do this is
-simply to use an IP address instead of a hostname.
+The WebHook URL needs to be "http://yourserver.com/some/private/path" and
+should not trigger any of the mounted apps. One way to do this is to specify
+
+  "User-Agent" => qr{^(?:(?!GitHub-Hookshot).)*$}
+
+in the mount configuration.
 
 =back
 


### PR DESCRIPTION
A better recommendation for how to handle Webhook URLs.  The GitHub Webhook request has a User-Agent header set that contains GitHub-Hookshot.  If the mount configuration matches on all requests except those that match the GitHub-Hookshot User-Agent then the Reload plugin will be able to function as expected and even allow the Webhook URL to have the same Host specified as one would expect.

This is especially convenient when toadfarm is running behind nginx and you don't want to have to specify a special server name specifically for webhooking.