### PR TITLE
Complete iptables example; minor typos

### DIFF
--- a/lib/Toadfarm/Manual/RunningToadfarm.pod
+++ b/lib/Toadfarm/Manual/RunningToadfarm.pod
@@ -149,7 +149,24 @@ C<toadfarm> as a normal user instead of "root".
   $ iptables -t nat -A PREROUTING -i eth0 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 8080
   $ iptables -t nat -A PREROUTING -i eth0 -p tcp -m tcp --dport 443 -j REDIRECT --to-ports 8443
 
-(You need to replace "eth0" with the appropriate interface)
+Replace "eth0" with the appropriate interface.  IP Forwarding in the
+kernel must also be enabled.  On most Linux distributions:
+
+  $ sysctl net.ipv4.ip_forward      # check
+  $ sysctl -w net.ipv4.ip_forward=1 # set
+
+The setting can be permanently enabled from /etc/sysctl.conf as:
+
+  net.ipv4.ip_forward = 1
+
+whereas on most *BSD and OSX, the setting for sysctl and
+/etc/sysctl.conf is
+
+  net.inet.ip.forwarding = 1
+
+See L<https://en.wikipedia.org/wiki/Sysctl#Examples> for further detail.
+
+=head2 Running as a non-privileged user
 
 You need to use L<Mojolicious::Plugin::SetUserGroup> if you want to start
 L<Toadfarm> as root and then change to a less privileged user in the workers.

--- a/lib/Toadfarm/Manual/RunningToadfarm.pod
+++ b/lib/Toadfarm/Manual/RunningToadfarm.pod
@@ -146,13 +146,13 @@ Setting up iptables rules will allow Toadfarm to listen to port 8080, while
 still receiving traffic on the default port. This way you can start and run
 C<toadfarm> as a normal user instead of "root".
 
-  $ iptables -A PREROUTING -i eth0 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 8080
-  $ iptables -A PREROUTING -i eth0 -p tcp -m tcp --dport 443 -j REDIRECT --to-ports 8443
+  $ iptables -t nat -A PREROUTING -i eth0 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 8080
+  $ iptables -t nat -A PREROUTING -i eth0 -p tcp -m tcp --dport 443 -j REDIRECT --to-ports 8443
 
 (You need to replace "eth0" with the appropriate interface)
 
 You need to use L<Mojolicious::Plugin::SetUserGroup> if you want to start
-L<Toadfarm> as root and then change to a less priviledged used in the workers.
+L<Toadfarm> as root and then change to a less privileged user in the workers.
 Example:
 
   # logging, mount, ...


### PR DESCRIPTION
Without `-t nat`, iptables defaults to the `filter` chain, which fails with error:

    iptables: No chain/target/match by that name.

Might also want to note here that IP Forwarding must be enabled, which can be verified by:

    cat /proc/sys/net/ipv4/ip_forward

which should return `1`.