### PR TITLE
rewrite base based on mount_point

### DIFF
--- a/lib/Toadfarm.pm
+++ b/lib/Toadfarm.pm
@@ -159,7 +159,11 @@ sub _mount_apps {
     if (@over) {
       $self->log->info("Mounting @{[$app->moniker]} with conditions");
       unshift @over, "sub { my \$h = \$_[1]->req->headers;\nlocal \$1;";
-      push @over, "\$_[1]->req->url->base(Mojo::URL->new(\$1 || '$request_base'));" if $request_base;
+      if ( $request_base ) {
+        push @over, "\$_[1]->req->url->base(Mojo::URL->new(\$1 || '$request_base'));";
+      } elsif ( $mount_point ) {
+        push @over, "\$_[1]->req->url->base(Mojo::URL->new(\$_[1]->req->url->path('$mount_point')->to_abs));";
+      }
       push @over, "return 1; }";
       $routes->add_condition("toadfarm_condition_$self->{mounted}", => eval "@over" || die "@over: $@");
       $routes->route($mount_point || '/')->detour(app => $app)->over("toadfarm_condition_$self->{mounted}");


### PR DESCRIPTION
I wonder if I'm misunderstanding something.  I have a lite_app and here's my Toadfarm configuration:

```
mount '/var/mojo/apps/example' => {
  "Host" => qr{^(www\.)?example\.fm$},
  mount_point => "/example",
};
```
But HTML such as `<img src="css/styles.css">` gives a 404 because the browser is looking to "/css/styles.css"
So then I try `<%= image "css/styles.css" %>` and I get the same problem.

So then I tried patching Toadfarm to what's here and it's working great for me.  But the fact that I needed this change, does it indicate that I'm doing something wrong either in my Toadfarm config, my app, or my HTML?  Does this patch introduce bigger problems in other situations?

I don't want to use X-Request-Base because 1) I might not be behind a proxy and 2) my proxy has a default configuration that passes everything to my Toadfarm instance.  I'd prefer to not have to modify my nginx proxy config every time I want to add a new app.

Does this make sense?