### PR TITLE
mojolicious v9.0 compatibility

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,7 @@ my %WriteMakefileArgs = (
   EXE_FILES      => [qw()],
   BUILD_REQUIRES => {},
   TEST_REQUIRES  => {'Test::More' => '0.88'},
-  PREREQ_PM      => {'File::Which' => '1.00', 'Mojolicious' => '8.00'},
+  PREREQ_PM      => {'File::Which' => '1.00', 'Mojolicious' => '8.73'},
   META_MERGE     => {
     'dynamic_config' => 0,
     'meta-spec'      => {version => 2},

--- a/t/basic.conf
+++ b/t/basic.conf
@@ -13,7 +13,7 @@
       'config' => { foo => 123 },
     },
   ],
-  plugins => [
+  tf_plugins => [
     't::lib::Plugin' => ['yikes'],
   ],
 }

--- a/t/basic.t
+++ b/t/basic.t
@@ -23,6 +23,6 @@ $t->get_ok('/', {'X-Request-Base' => 'http://localhost:1234/yikes'})->status_is(
 $t->get_ok('/info')->status_is(200)->content_is('["yikes"]');
 
 $t->get_ok('/config.json', {'X-Request-Base' => 'http://localhost:1234/yikes'})->status_is(200)->json_is('/foo', 123)
-  ->json_has('/plugins', 'inherit toadfarm config')->json_has('/apps')->json_is('/apps/1/Host', 'te.st');
+  ->json_has('/tf_plugins', 'inherit toadfarm config')->json_has('/apps')->json_is('/apps/1/Host', 'te.st');
 
 done_testing;

--- a/t/custom-error.t
+++ b/t/custom-error.t
@@ -10,7 +10,7 @@ plan skip_all => "MOJO_CONFIG=$ENV{MOJO_CONFIG}" unless -r $ENV{MOJO_CONFIG};
 
 my $t = Test::Mojo->new('Toadfarm');
 
-$t->get_ok('/')->status_is(404)->content_like(qr{^404444444440404040404040404});
+$t->get_ok('/blah')->status_is(404)->content_like(qr{^404444444440404040404040404});
 
 $t->get_ok('/yay.txt')->status_is(200)->content_like(qr{^yay});
 

--- a/t/dsl-basic.t
+++ b/t/dsl-basic.t
@@ -32,7 +32,7 @@ $t->get_ok('/', {'X-Request-Base' => 'http://localhost:1234/yikes'})->status_is(
 $t->get_ok('/info')->status_is(200)->content_is('["yikes"]');
 
 $t->get_ok('/config.json', {'X-Request-Base' => 'http://localhost:1234/yikes'})->status_is(200)->json_is('/foo', 123)
-  ->json_has('/plugins', 'inherit toadfarm config')->json_has('/apps')->json_is('/apps/1/Host', 'te.st')
+  ->json_has('/tf_plugins', 'inherit toadfarm config')->json_has('/apps')->json_is('/apps/1/Host', 'te.st')
   ->json_is('/hypnotoad/listen', ['http://*:5000'], 'listen')->json_is('/hypnotoad/proxy', 1, 'proxy')
   ->json_is('/log/combined', 1, 'combined')->json_is('/log/level', 'debug');
 

--- a/t/log.conf
+++ b/t/log.conf
@@ -4,7 +4,7 @@
     level => 'debug',
     combined => 1,
   },
-  plugins => [
+  tf_plugins => [
     AccessLog => {},
   ],
 }


### PR DESCRIPTION
various cleanups have been made to the routing methods provided by
Mojolicious::Routes::Route[1].

    * detour method has been removed, using ->partial(1)->to() instead
    * route method has been removed, using any instead.
    * over method has been renamed to requires.
    * via method has been renamed to methods.

the `plugins` key in a configuration file will now be used to load
deployment specific plugins. this means this top-level key is now
reserved in configuration and should not be used for other purposes.
because of this the `plugins` key in toadfarm config has been renamed to
`tf_plugins`

the minimum required version of Mojolicious has been bumped to 8.73,
which is the version before 9.00 - this allows users to upgrade this
distribution without having to go fully v9 of Mojolicious

[1] https://github.com/mojolicious/mojo/wiki/Upgrading